### PR TITLE
fix: schema defaults to public if schema is not present

### DIFF
--- a/datachecks/integrations/databases/postgres.py
+++ b/datachecks/integrations/databases/postgres.py
@@ -38,7 +38,7 @@ class PostgresDataSource(SQLDataSource):
                 port=self.data_connection.get("port"),
                 database=self.data_connection.get("database"),
             )
-            schema = self.data_connection.get("schema")
+            schema = self.data_connection.get("schema") or "public"
             engine = create_engine(
                 url,
                 connect_args={"options": f"-csearch_path={schema}"},


### PR DESCRIPTION
### Fixes/Implements #136 

## Description

In a Postgres configuration file, if the schema is not present, then datachecks will use the "public" schema as default.

## Type of change

Delete irrelevant options.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- [x] Locally Tested
- [x] Needs Testing From Production