### PR TITLE
Remove workflow_dispatch inputs from PyPI publish workflow

### DIFF
--- a/.github/workflows/poetry_publish.yaml
+++ b/.github/workflows/poetry_publish.yaml
@@ -1,12 +1,6 @@
 name: Publish to PyPI
 
 on:
-  workflow_dispatch:
-    inputs:
-      python_version:
-        description: "Python version to use (default: 3.12)"
-        required: false
-        default: "3.12"
   workflow_call:
     inputs:
       python_version:


### PR DESCRIPTION
### Fixes/Implements #

## Description

Summary Goes here.

## Type of change

Delete irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] Locally Tested
- [ ] Needs Testing From Production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow triggers to allow only programmatic invocation; manual triggering of the workflow is no longer available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->