### PR TITLE
feat: add get_table_foreign_key_info method for MySQL and Oracle database

### DIFF
--- a/dcs_core/integrations/databases/mysql.py
+++ b/dcs_core/integrations/databases/mysql.py
@@ -15,6 +15,7 @@
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple, Union
 
+from loguru import logger
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import URL
 
@@ -420,7 +421,7 @@ class MysqlDataSource(DB2DataSource):
         try:
             rows = self.fetchall(query)
         except Exception as e:
-            print(f"Failed to fetch fk info for dataset: {table_name} ({e})")
+            logger.error(f"Failed to fetch fk info for dataset: {table_name} ({e})")
             return []
 
         data = [

--- a/dcs_core/integrations/databases/oracle.py
+++ b/dcs_core/integrations/databases/oracle.py
@@ -702,7 +702,7 @@ class OracleDataSource(SQLDataSource):
         )
         timestamp = int(time.time())
         return f"dcs_view_{timestamp}_{random_string.lower()}".upper()
-    
+
     def get_table_foreign_key_info(self, table_name: str, schema: str | None = None):
         schema = schema or self.schema_name
 
@@ -732,7 +732,7 @@ class OracleDataSource(SQLDataSource):
         try:
             rows = self.fetchall(query)
         except Exception as e:
-            print(f"Failed to fetch fk info for dataset: {table_name} ({e})")
+            logger.error(f"Failed to fetch fk info for dataset: {table_name} ({e})")
             return []
 
         data = [


### PR DESCRIPTION
… sources

### Fixes/Implements #

## Description

Summary Goes here.

## Type of change

Delete irrelevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

- [ ] Locally Tested
- [ ] Needs Testing From Production

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added functionality to retrieve and display foreign key relationship information for database tables across MySQL and Oracle database sources. Returns constraint names, column mappings, and referenced table details with error handling for failed queries.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->